### PR TITLE
strpcpu_s: remove unsed redundant variable overlap_bumper

### DIFF
--- a/safeclib/stpncpy_s.c
+++ b/safeclib/stpncpy_s.c
@@ -113,7 +113,6 @@ stpncpy_s(char *dest, rsize_t dmax, const char *src, rsize_t smax, errno_t *err)
 {
     rsize_t orig_dmax;
     char *orig_dest;
-    const char *overlap_bumper;
 
     if (dest == NULL) {
         invoke_safe_str_constraint_handler("stpncpy_s: dest is null",


### PR DESCRIPTION
Variable overlap_bumper is redundant so remove it.

Signed-off-by: Colin Ian King <colin.king@canonical.com>